### PR TITLE
Add plugin skeleton with DI and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: Continuous Integration
+
+on:
+  push:
+    branches: [ '*' ]
+  pull_request:
+    branches: [ '*' ]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          tools: composer, phpunit
+      - run: composer install --no-progress --no-suggest --prefer-dist
+      - run: vendor/bin/phpunit --configuration phpunit.xml

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,10 @@ wp-config.php
 # Note: If you wish to whitelist themes,
 # uncomment the next line
 #/wp-content/themes
+# Composer
+/vendor/
+composer.lock
+
+# Build artifacts
+/build/dist/
+\n.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# WP Modern Plugin Skeleton
+
+This repository provides a starting point for building modern WordPress plugins with a clean architecture and dependency injection.
+
+## Features
+
+- Hexagonal architecture structure (`Domain`, `Application`, `Infrastructure`)
+- PHP-DI container configuration (`config/di.php`)
+- PSR-4 autoloading via Composer
+- GitHub Actions workflow for tests
+- PHPUnit test setup with code coverage
+- Build script for packaging the plugin
+- Automatic plugin header generator (`generate-header.php`)
+
+## Usage
+
+1. Install dependencies
+   ```bash
+   composer install
+   ```
+2. Run tests
+   ```bash
+   composer test
+   ```
+3. Generate plugin header
+   ```bash
+   composer generate-header
+   ```
+4. Package plugin
+   ```bash
+   ./build/build.sh
+   ```

--- a/build/build.sh
+++ b/build/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+DIST_DIR=build/dist
+PLUGIN_NAME=wp-modern-plugin-skeleton
+PLUGIN_DIR=$DIST_DIR/$PLUGIN_NAME
+
+rm -rf "$DIST_DIR"
+mkdir -p "$PLUGIN_DIR"
+
+rsync -av --delete \
+  --exclude='.git' \
+  --exclude='build' \
+  --exclude='tests' \
+  --exclude='.github' \
+  --exclude='*.zip' \
+  --exclude='phpunit.*' \
+  --exclude='.gitignore' \
+  --exclude='.gitattributes' \
+  ./ "$PLUGIN_DIR/"

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,24 @@
+{
+  "name": "example/wp-modern-plugin-skeleton",
+  "description": "Modern WordPress plugin skeleton using hexagonal architecture",
+  "type": "wordpress-plugin",
+  "license": "MIT",
+  "require": {
+    "php": "^8.2",
+    "php-di/php-di": "^7.0"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^11.5"
+  },
+  "autoload": {
+    "psr-4": {
+      "WP\\Skeleton\\": "src/"
+    }
+  },
+  "scripts": {
+    "generate-header": [
+      "php generate-header.php"
+    ],
+    "test": "vendor/bin/phpunit --configuration phpunit.xml"
+  }
+}

--- a/config/di.php
+++ b/config/di.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use function DI\autowire;
+use function DI\create;
+
+return [
+    // Example binding for a WordPress settings repository
+    // SettingsRepositoryInterface::class => autowire(WordpressSettingsRepository::class),
+];

--- a/generate-header.php
+++ b/generate-header.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+$file = __DIR__ . '/plugin-skeleton.php';
+$composer = json_decode(file_get_contents(__DIR__ . '/composer.json'), true);
+
+exec('git describe --tags --abbrev=0 2>/dev/null', $out, $exit);
+$version = $exit === 0 ? trim($out[0]) : '0.1.0';
+
+$name = $composer['name'] ?? 'wp-skeleton';
+$description = $composer['description'] ?? 'Modern WordPress plugin skeleton';
+$authorName = $composer['authors'][0]['name'] ?? 'Unknown';
+
+$header = <<<PHP
+/**
+ * Plugin Name: WP Modern Plugin Skeleton
+ * Description: {$description}
+ * Version: {$version}
+ * Author: {$authorName}
+ * License: GPLv2 or later
+ * License URI: https://www.gnu.org/licenses/gpl-2.0.html
+ * Domain Path: /languages
+ * Text Domain: wp-modern-skeleton
+ * Requires at least: 6.0
+ * Tested up to: 6.8
+ * Requires PHP: 8.2
+ * Stable tag: {$version}
+ */
+PHP;
+
+$code = file_get_contents($file);
+if ($code === false) {
+    fwrite(STDERR, "Could not read $file\n");
+    exit(1);
+}
+
+$pattern = '/(<\?php\s*)(?:\/\*\*.*?\*\/\s*)?/s';
+$replacement = '$1' . $header . "\n\n";
+
+$newCode = preg_replace($pattern, $replacement, $code, 1);
+
+if ($newCode === null) {
+    fwrite(STDERR, "Regex error while updating header.\n");
+    exit(1);
+}
+
+file_put_contents($file, $newCode);
+echo "Plugin header injected (version: $version)\n";

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php"
+         colors="true"
+         stopOnFailure="false">
+    <testsuites>
+        <testsuite name="Plugin Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/plugin-skeleton.php
+++ b/plugin-skeleton.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Plugin Name: WP Modern Plugin Skeleton
+ * Description: Modern WordPress plugin skeleton using hexagonal architecture
+ * Version: 0.1.0
+ * Author: Unknown
+ * License: GPLv2 or later
+ * License URI: https://www.gnu.org/licenses/gpl-2.0.html
+ * Domain Path: /languages
+ * Text Domain: wp-modern-skeleton
+ * Requires at least: 6.0
+ * Tested up to: 6.8
+ * Requires PHP: 8.2
+ * Stable tag: 0.1.0
+ */
+
+declare(strict_types=1);
+
+use WP\Skeleton\Infrastructure\DI\ContainerProvider;
+
+defined('ABSPATH') or die('No script kiddies please!');
+
+require_once __DIR__ . '/vendor/autoload.php';
+
+// Example of retrieving the DI container
+ContainerProvider::getContainer();

--- a/src/Application/GreetingApplication.php
+++ b/src/Application/GreetingApplication.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WP\Skeleton\Application;
+
+use WP\Skeleton\Domain\SampleService;
+
+class GreetingApplication
+{
+    public function __construct(private SampleService $service)
+    {
+    }
+
+    public function greet(string $name): string
+    {
+        return $this->service->greet($name);
+    }
+}

--- a/src/Domain/SampleService.php
+++ b/src/Domain/SampleService.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WP\Skeleton\Domain;
+
+class SampleService
+{
+    public function greet(string $name): string
+    {
+        return "Hello, {$name}!";
+    }
+}

--- a/src/Infrastructure/DI/ContainerProvider.php
+++ b/src/Infrastructure/DI/ContainerProvider.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WP\Skeleton\Infrastructure\DI;
+
+use DI\Container;
+use DI\ContainerBuilder;
+
+final class ContainerProvider
+{
+    private static ?Container $container = null;
+
+    public static function getContainer(): Container
+    {
+        if (self::$container === null) {
+            $builder = new ContainerBuilder();
+            $builder->addDefinitions(dirname(__DIR__, 3) . '/config/di.php');
+            self::$container = $builder->build();
+        }
+
+        return self::$container;
+    }
+}

--- a/src/Infrastructure/WordPress/SettingsRepository.php
+++ b/src/Infrastructure/WordPress/SettingsRepository.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WP\Skeleton\Infrastructure\WordPress;
+
+class SettingsRepository
+{
+    public function get(string $key, mixed $default = null): mixed
+    {
+        return get_option($key, $default);
+    }
+
+    public function update(string $key, mixed $value): bool
+    {
+        return update_option($key, $value);
+    }
+}

--- a/tests/SampleServiceTest.php
+++ b/tests/SampleServiceTest.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use WP\Skeleton\Domain\SampleService;
+
+class SampleServiceTest extends TestCase
+{
+    public function testGreet(): void
+    {
+        $service = new SampleService();
+        $this->assertSame('Hello, Codex!', $service->greet('Codex'));
+    }
+}


### PR DESCRIPTION
## Summary
- set up folders for modern WordPress plugin skeleton
- add DI container provider and config example
- include simple domain service and application layer
- create GitHub Actions workflow and build script
- add PHPUnit test setup with example test
- script for automatic plugin header generation

## Testing
- `composer install`
- `vendor/bin/phpunit --configuration phpunit.xml`
- `php generate-header.php`
- `./build/build.sh`


------
https://chatgpt.com/codex/tasks/task_e_688a9b5e7e6083298e512bcb636edb08