### PR TITLE
Integrate modular DI container

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ This repository provides a starting point for building modern WordPress plugins 
 ## Features
 
 - Hexagonal architecture structure (`Domain`, `Application`, `Infrastructure`)
-- PHP-DI container configuration (`config/di.php`)
+- Modular dependency injection container using `ContainerProvider` and
+  `*ContainerConfigurator` classes
 - PSR-4 autoloading via Composer
 - GitHub Actions workflow for tests
 - PHPUnit test setup with code coverage

--- a/plugin-skeleton.php.dist
+++ b/plugin-skeleton.php.dist
@@ -17,10 +17,19 @@
 declare(strict_types=1);
 
 use WP\Skeleton\Infrastructure\DI\ContainerProvider;
+use WP\Skeleton\Shared\Plugin\PluginContext;
 
 defined('ABSPATH') or die('No script kiddies please!');
 
 require_once __DIR__ . '/vendor/autoload.php';
 
-// Example of retrieving the DI container
-ContainerProvider::getContainer();
+ContainerProvider::setPluginContext(
+    new PluginContext(
+        __FILE__,
+        'wp-modern-plugin-skeleton',
+        'https://example.com'
+    )
+);
+
+$container = ContainerProvider::getContainer();
+// $container can now be used to fetch services

--- a/src/Application/DI/ApplicationContainerConfigurator.php
+++ b/src/Application/DI/ApplicationContainerConfigurator.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WP\Skeleton\Application\DI;
+
+use DI\ContainerBuilder;
+use WP\Skeleton\Shared\DI\ContainerConfiguratorInterface;
+
+class ApplicationContainerConfigurator implements ContainerConfiguratorInterface
+{
+    public function configure(ContainerBuilder $builder): void
+    {
+        $builder->addDefinitions([
+            // Application services
+        ]);
+    }
+}

--- a/src/Domain/DI/DomainContainerConfigurator.php
+++ b/src/Domain/DI/DomainContainerConfigurator.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WP\Skeleton\Domain\DI;
+
+use DI\ContainerBuilder;
+use WP\Skeleton\Shared\DI\ContainerConfiguratorInterface;
+
+class DomainContainerConfigurator implements ContainerConfiguratorInterface
+{
+    public function configure(ContainerBuilder $builder): void
+    {
+        $builder->addDefinitions([
+            // Domain services
+        ]);
+    }
+}

--- a/src/Infrastructure/DI/ContainerProvider.php
+++ b/src/Infrastructure/DI/ContainerProvider.php
@@ -6,19 +6,70 @@ namespace WP\Skeleton\Infrastructure\DI;
 
 use DI\Container;
 use DI\ContainerBuilder;
+use WP\Skeleton\Application\DI\ApplicationContainerConfigurator;
+use WP\Skeleton\Domain\DI\DomainContainerConfigurator;
+use WP\Skeleton\Shared\DI\ContainerConfiguratorInterface;
+use WP\Skeleton\Shared\Plugin\PluginContext;
 
 final class ContainerProvider
 {
     private static ?Container $container = null;
+    private static ?PluginContext $pluginContext = null;
+
+    /** @var array<ContainerConfiguratorInterface> */
+    private static array $customConfigurators = [];
+
+    public static function addConfigurator(ContainerConfiguratorInterface $configurator): void
+    {
+        self::$customConfigurators[] = $configurator;
+    }
+
+    public static function setPluginContext(PluginContext $context): void
+    {
+        self::$pluginContext = $context;
+    }
 
     public static function getContainer(): Container
     {
-        if (self::$container === null) {
-            $builder = new ContainerBuilder();
-            $builder->addDefinitions(dirname(__DIR__, 3) . '/config/di.php');
-            self::$container = $builder->build();
+        if (self::$container !== null) {
+            return self::$container;
         }
 
+        if (self::$pluginContext === null) {
+            throw new \RuntimeException('Plugin context must be set before building the container.');
+        }
+
+        $projectRoot = dirname(__DIR__, 3);
+        $cacheDir = $projectRoot.'/cache/container';
+
+        $builder = new ContainerBuilder();
+
+        $env = function_exists('wp_get_environment_type')
+            ? wp_get_environment_type()
+            : 'production';
+
+        if (!in_array($env, ['local', 'development'], true)) {
+            $builder->writeProxiesToFile(true, $cacheDir.'/proxies');
+            $builder->enableCompilation($cacheDir.'/compiled');
+        }
+
+        self::configure($builder);
+
+        self::$container = $builder->build();
         return self::$container;
+    }
+
+    private static function configure(ContainerBuilder $builder): void
+    {
+        $configurators = [
+            new ApplicationContainerConfigurator(),
+            new DomainContainerConfigurator(),
+            new InfrastructureContainerConfigurator(self::$pluginContext),
+            ...self::$customConfigurators,
+        ];
+
+        foreach ($configurators as $configurator) {
+            $configurator->configure($builder);
+        }
     }
 }

--- a/src/Infrastructure/DI/InfrastructureContainerConfigurator.php
+++ b/src/Infrastructure/DI/InfrastructureContainerConfigurator.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WP\Skeleton\Infrastructure\DI;
+
+use DI\ContainerBuilder;
+use WP\Skeleton\Infrastructure\WordPress\SettingsRepository;
+use WP\Skeleton\Shared\DI\ContainerConfiguratorInterface;
+use WP\Skeleton\Shared\Plugin\PluginContext;
+
+use function DI\autowire;
+
+final readonly class InfrastructureContainerConfigurator implements ContainerConfiguratorInterface
+{
+    public function __construct(private PluginContext $pluginContext)
+    {
+    }
+
+    public function configure(ContainerBuilder $builder): void
+    {
+        $builder->addDefinitions([
+            SettingsRepository::class => autowire(SettingsRepository::class),
+            // Other infrastructure services
+        ]);
+    }
+}

--- a/src/Shared/DI/ContainerConfiguratorInterface.php
+++ b/src/Shared/DI/ContainerConfiguratorInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WP\Skeleton\Shared\DI;
+
+use DI\ContainerBuilder;
+
+interface ContainerConfiguratorInterface
+{
+    public function configure(ContainerBuilder $builder): void;
+}

--- a/src/Shared/Plugin/PluginContext.php
+++ b/src/Shared/Plugin/PluginContext.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WP\Skeleton\Shared\Plugin;
+
+final class PluginContext
+{
+    public function __construct(
+        public readonly string $pluginFile,
+        public readonly string $pluginSlug,
+        public readonly string $pluginInfoUrl
+    ) {
+    }
+}

--- a/tests/ContainerProviderTest.php
+++ b/tests/ContainerProviderTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use DI\Container;
+use WP\Skeleton\Infrastructure\DI\ContainerProvider;
+use WP\Skeleton\Shared\Plugin\PluginContext;
+
+class ContainerProviderTest extends TestCase
+{
+    public function testReturnsSingletonContainer(): void
+    {
+        ContainerProvider::setPluginContext(new PluginContext(__FILE__, 'test', 'info'));
+        $c1 = ContainerProvider::getContainer();
+        $c2 = ContainerProvider::getContainer();
+        $this->assertInstanceOf(Container::class, $c1);
+        $this->assertSame($c1, $c2);
+    }
+}


### PR DESCRIPTION
## Summary
- add ContainerProvider with plugin context support and caching
- introduce ContainerConfigurator interface and configurators for each layer
- update plugin bootstrap to set PluginContext
- mention ContainerProvider in README
- add tests for ContainerProvider

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_688d3ab5f9a88329aa0c985c09953cf2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a modular and extensible dependency injection container setup, enabling plugin-specific context and service configurators.
  * Added new configurator classes for application, domain, and infrastructure layers.
  * Introduced a plugin context class to encapsulate plugin metadata.

* **Documentation**
  * Updated the README to clarify the new modular approach to dependency injection configuration.

* **Tests**
  * Added tests to ensure the container provider returns a singleton instance and respects plugin context configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->