### PR TITLE
Add Wordpress adapter skeleton classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
   },
   "autoload": {
     "psr-4": {
-      "WP\\Skeleton\\": "src/"
+      "WP\\Skeleton\\": "src/",
+      "N3XT0R\\XPub\\Adapter\\": "src/Adapter/"
     }
   },
   "scripts": {

--- a/plugin-skeleton.php.dist
+++ b/plugin-skeleton.php.dist
@@ -16,20 +16,11 @@
 
 declare(strict_types=1);
 
-use WP\Skeleton\Infrastructure\DI\ContainerProvider;
-use WP\Skeleton\Shared\Plugin\PluginContext;
+use N3XT0R\XPub\Adapter\WordpressPlugin;
 
 defined('ABSPATH') or die('No script kiddies please!');
 
 require_once __DIR__ . '/vendor/autoload.php';
 
-ContainerProvider::setPluginContext(
-    new PluginContext(
-        __FILE__,
-        'wp-modern-plugin-skeleton',
-        'https://example.com'
-    )
-);
+WordpressPlugin::init(__FILE__);
 
-$container = ContainerProvider::getContainer();
-// $container can now be used to fetch services

--- a/src/Adapter/WordpressCron.php
+++ b/src/Adapter/WordpressCron.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace N3XT0R\XPub\Adapter;
+
+final class WordpressCron
+{
+    public function register(): void
+    {
+        // TODO: register cron events
+    }
+
+    public function handle(): void
+    {
+        // TODO: handle cron execution
+    }
+}

--- a/src/Adapter/WordpressPlugin.php
+++ b/src/Adapter/WordpressPlugin.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace N3XT0R\XPub\Adapter;
+
+use WP\Skeleton\Infrastructure\DI\ContainerProvider;
+use WP\Skeleton\Shared\Plugin\PluginContext;
+
+final class WordpressPlugin
+{
+    private function __construct()
+    {
+    }
+
+    public static function init(string $pluginFile): void
+    {
+        ContainerProvider::setPluginContext(
+            new PluginContext(
+                $pluginFile,
+                'wp-modern-plugin-skeleton',
+                'https://example.com'
+            )
+        );
+
+        // Build the container. Services can now be fetched via ContainerProvider
+        ContainerProvider::getContainer();
+    }
+}


### PR DESCRIPTION
## Summary
- create skeleton classes `WordpressPlugin` and `WordpressCron` under `N3XT0R\XPub\Adapter`
- autoload new adapter namespace via Composer
- streamline plugin bootstrap to call `WordpressPlugin::init(__FILE__)`

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688d4317bef883299572fec1e31c55c5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced new plugin initialization and cron management classes to improve integration and scheduling capabilities.
* **Refactor**
  * Simplified plugin bootstrap process for easier initialization and reduced setup complexity.
* **Chores**
  * Updated autoload configuration to support additional namespaces for improved code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->